### PR TITLE
remove shapely imports from tests

### DIFF
--- a/src/test/featuretest.py
+++ b/src/test/featuretest.py
@@ -5,8 +5,7 @@ import time
 import shutil
 from geogigpy import geogig
 from geogigpy.feature import Feature
-from shapely.geometry import Polygon
-from shapely.geometry.multipolygon import MultiPolygon
+from geogigpy.geometry import Geometry
 from testrepo import testRepo
 
 class GeogigFeatureTest(unittest.TestCase):
@@ -39,9 +38,9 @@ class GeogigFeatureTest(unittest.TestCase):
         self.assertTrue("parktype" in data)
         self.assertTrue("area" in data)
         self.assertTrue("perimeter" in data)  
-        self.assertTrue("the_geom" in data)  
-        self.assertTrue(isinstance(data["the_geom"][0], Polygon))        
-        
+        self.assertTrue("the_geom" in data)
+        self.assertTrue(isinstance(data["the_geom"], Geometry))
+
     def testDiff(self):
         feature = Feature(self.repo, geogig.HEAD, "parks/5")
         featureB = Feature(self.repo, geogig.HEAD + "~1", "parks/5")
@@ -75,7 +74,7 @@ class GeogigFeatureTest(unittest.TestCase):
     def testGeom(self):
         feature = Feature(self.repo, geogig.HEAD, "parks/5")
         geom = feature.geom
-        self.assertTrue(isinstance(geom, MultiPolygon)) 
+        self.assertTrue(isinstance(geom, Geometry))
         
     def testGeomFieldName(self):
         feature = Feature(self.repo, geogig.HEAD, "parks/5")

--- a/src/test/repotest.py
+++ b/src/test/repotest.py
@@ -7,7 +7,7 @@ from geogigpy.diff import TYPE_MODIFIED
 from geogigpy.feature import Feature
 import unittest
 from geogigpy import geogig
-from shapely.geometry import MultiPolygon
+from geogigpy.geometry import Geometry
 from geogigpy.osmmapping import OSMMapping, OSMMappingRule
 import datetime
 from testrepo import testRepo
@@ -136,8 +136,8 @@ class GeogigRepositoryTest(unittest.TestCase):
         self.assertTrue("parktype" in data)
         self.assertTrue("area" in data)
         self.assertTrue("perimeter" in data)
-        self.assertTrue("the_geom" in data)        
-        self.assertTrue(isinstance(data["the_geom"][0], MultiPolygon))
+        self.assertTrue("the_geom" in data)
+        self.assertTrue(isinstance(data["the_geom"][0], Geometry))
 
     def testFeatureDataNonExistentFeature(self):  
         return       


### PR DESCRIPTION
Commit fe49753 removed shapely dependencies. This pull requests updates a few tests that are currently failing due to a requirement for shapely. These tests have been updated to check for geogigpy `Geometry` instances rather then shapely `Polygon` and `MultiPolygons`.
